### PR TITLE
fix npm release — closes #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jquery-onmutate",
   "version": "1.4.2",
   "description": "A MutationObserver wrapper for jQuery, allowing you to listen for element creation, attribute modification, and text changes.",
-  "main": "jquery.onmutate.js",
+  "main": "src/jquery.onmutate.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
Update the `main` path in package.json to point to the new location under the `src` directory.